### PR TITLE
Fixes for Kinetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(object_recognition_clusters)
 
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs object_recognition_msgs roscpp
-  rospy tf ecto ecto_ros pcl_ros
+  rospy tf ecto ecto_ros pcl_ros cv_bridge
 )
 
 catkin_python_setup()

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>ecto</build_depend>
   <build_depend>ecto_ros</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>object_recognition_msgs</run_depend>
@@ -27,6 +28,7 @@
   <run_depend>ecto</run_depend>
   <run_depend>ecto_ros</run_depend>
   <run_depend>pcl_ros</run_depend>
+  <run_depend>cv_bridge</run_depend>
 
   <export>
   </export>

--- a/src/io/PointCloudMsgAssembler.cpp
+++ b/src/io/PointCloudMsgAssembler.cpp
@@ -41,7 +41,7 @@
 #include <boost/foreach.hpp>
 
 #include <ecto/ecto.hpp>
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 
 // ROS includes
 #include <sensor_msgs/Image.h>


### PR DESCRIPTION
On Kinetic I was getting:

```
/home/sam/tabletop_ws/src/object_recognition_clusters/src/io/PointCloudMsgAssembler.cpp:44:28: fatal error: opencv2/core.hpp: No such file or directory
```

Which was solved by adding something that found opencv, and as I read in the migration guide for opencv3, better to use cv_bridge to pull that dependency.

Also on opencv3 the includes change, so I also changed that.

@bmagyar coming back to life!